### PR TITLE
:heavy_plus_sign: Add SDL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ endif ()
 find_package(glm REQUIRED)
 find_package(stduuid REQUIRED)
 find_package(GSL REQUIRED)
+find_package(SDL2 REQUIRED)
+find_package(SDL2_image REQUIRED)
+find_package(SDL2_ttf REQUIRED)
 
 # Include subdirectories for common, physics, and graphics
 add_subdirectory(src/common)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -5,6 +5,9 @@ cmake/3.29.7
 glm/1.0.1
 stduuid/1.2.3
 gsl/2.7.1
+sdl_image/[~2.6]
+sdl_ttf/[~2.0]
+sdl/[~2.28]
 
 [generators]
 CMakeDeps

--- a/src/graphics/CMakeLists.txt
+++ b/src/graphics/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(StellarForgeGraphics STATIC)
 add_library(StellarForge::Graphics ALIAS StellarForgeGraphics)
 add_dependencies(StellarForgeGraphics StellarForgeCommon)
+target_link_libraries(StellarForgeGraphics PUBLIC SDL2::SDL2 SDL2::SDL2main SDL2_image::SDL2_image sdl_ttf::sdl_ttf)
 
 target_sources(StellarForgeGraphics
         PUBLIC


### PR DESCRIPTION
This pull request includes updates to the `CMakeLists.txt` files to add new dependencies for the project. The most important changes involve adding SDL2 libraries and linking them to the graphics module.

Dependency additions:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR44-R46): Added `SDL2`, `SDL2_image`, and `SDL2_ttf` as required packages.

Library linking:

* [`src/graphics/CMakeLists.txt`](diffhunk://#diff-11a59fa4b532ee3177beccd92e47861565367f6e4738f3cd38ff113758b3c12aR4): Linked `StellarForgeGraphics` with `SDL2::SDL2`, `SDL2::SDL2main`, `SDL2_image::SDL2_image`, and `sdl_ttf::sdl_ttf`.