### PR TITLE
:sparkles: Create abstracts to simplify component creation

### DIFF
--- a/src/common/AComponent.cpp
+++ b/src/common/AComponent.cpp
@@ -1,0 +1,22 @@
+/*
+** EPITECH PROJECT, 2024
+** StellarForge
+** File description:
+** AComponent.cpp
+*/
+
+#include "AComponent.hpp"
+
+AComponent::AComponent(IObject *owner, IMeta &meta) : _owner(owner), _meta(meta)
+{
+}
+
+IObject *AComponent::getOwner()
+{
+    return this->_owner;
+}
+
+IComponent::IMeta &AComponent::getMeta() const
+{
+    return this->_meta;
+}

--- a/src/common/AComponent.cpp
+++ b/src/common/AComponent.cpp
@@ -9,12 +9,12 @@
 
 AComponent::AComponent(IObject *owner, IMeta &meta) : _meta(meta)
 {
-    this->_uuid = ObjectManager::getInstance().generate_component_UUID(owner, this);
+    this->_uuid = ObjectManager::getInstance().generateComponentUUID(owner, this);
 }
 
 IObject *AComponent::getOwner()
 {
-    return ObjectManager::getInstance().get_object_from_component(this->_uuid);
+    return ObjectManager::getInstance().getObjectFromComponentUID(this->_uuid);
 }
 
 IComponent::IMeta &AComponent::getMeta() const

--- a/src/common/AComponent.cpp
+++ b/src/common/AComponent.cpp
@@ -9,7 +9,7 @@
 
 AComponent::AComponent(IObject *owner, IMeta &meta) : _meta(meta)
 {
-    this->_uuid = ObjectManager::getInstance().get_component_UUID(owner, this);
+    this->_uuid = ObjectManager::getInstance().generate_component_UUID(owner, this);
 }
 
 IObject *AComponent::getOwner()

--- a/src/common/AComponent.cpp
+++ b/src/common/AComponent.cpp
@@ -7,14 +7,13 @@
 
 #include "AComponent.hpp"
 
-AComponent::AComponent(IObject *owner, IMeta &meta) : _meta(meta)
+AComponent::AComponent(IObject *owner, IMeta &meta) : _owner(owner), _meta(meta)
 {
-    this->_uuid = ObjectManager::getInstance().generateComponentUUID(owner, this);
 }
 
 IObject *AComponent::getOwner()
 {
-    return ObjectManager::getInstance().getObjectFromComponentUID(this->_uuid);
+    return this->_owner;
 }
 
 IComponent::IMeta &AComponent::getMeta() const

--- a/src/common/AComponent.cpp
+++ b/src/common/AComponent.cpp
@@ -7,13 +7,14 @@
 
 #include "AComponent.hpp"
 
-AComponent::AComponent(IObject *owner, IMeta &meta) : _owner(owner), _meta(meta)
+AComponent::AComponent(IObject *owner, IMeta &meta) : _meta(meta)
 {
+    this->_uuid = ObjectManager::getInstance().get_component_UUID(owner, this);
 }
 
 IObject *AComponent::getOwner()
 {
-    return this->_owner;
+    return ObjectManager::getInstance().get_object_from_component(this->_uuid);
 }
 
 IComponent::IMeta &AComponent::getMeta() const

--- a/src/common/AComponent.hpp
+++ b/src/common/AComponent.hpp
@@ -1,0 +1,90 @@
+/*
+** EPITECH PROJECT, 2024
+** StellarForge
+** File description:
+** AComponent.hpp
+*/
+
+#ifndef ACOMPONENT_HPP
+#define ACOMPONENT_HPP
+
+#include "IComponent.hpp"
+
+/**
+ * @class AComponent
+ * @brief This class is the abstract class for the Component class
+ * @version v0.1.0
+ * @since v0.1.0
+ * @author Marius PAIN
+ */
+class AComponent : virtual public IComponent
+{
+public:
+ /**
+  * @brief The destructor of the AComponent class
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ ~AComponent() override = default;
+
+ /**
+  * @brief The update function of the component.
+  * This is meant to be runt by the parent object and update the component every frame
+  * @note This is a pure virtual function and must be implemented in the child class
+  * @see IComponent::runComponent
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ void runComponent() override = 0;
+
+ /**
+  * @brief Returns a non-owning and non-null pointer to the owner of the component
+  * @see IComponent::getOwner
+  * @return the owner of the component
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ [[nodiscard]] IObject* getOwner() override;
+
+ /**
+  * @brief Get the meta of the component
+  * @see IComponent::getMeta
+  * @return the meta of the component
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ [[nodiscard]] IMeta& getMeta() const override;
+
+protected:
+ /**
+  * @brief The constructor of the AComponent class
+  * @param owner The owner of the component
+  * @param meta The meta of the component
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ AComponent(IObject* owner, IMeta& meta);
+
+ /**
+  * @brief The owner of the component
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ IObject* _owner;
+
+ /**
+  * @brief The meta of the component
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ IMeta& _meta;
+};
+
+#endif //ACOMPONENT_HPP

--- a/src/common/AComponent.hpp
+++ b/src/common/AComponent.hpp
@@ -9,8 +9,6 @@
 #define ACOMPONENT_HPP
 
 #include "IComponent.hpp"
-#include "UUID.hpp"
-#include "managers/ObjectManager.hpp"
 
 /**
  * @class AComponent

--- a/src/common/AComponent.hpp
+++ b/src/common/AComponent.hpp
@@ -73,12 +73,12 @@ protected:
  AComponent(IObject* owner, IMeta& meta);
 
  /**
-  * @brief The UUID of the component
+  * @brief The owner of the component
   * @version v0.1.0
   * @since v0.1.0
-  * @author Aubane NOURRY
+  * @author Marius PAIN
  */
- UUID _uuid;
+ IObject* _owner;
 
  /**
   * @brief The meta of the component

--- a/src/common/AComponent.hpp
+++ b/src/common/AComponent.hpp
@@ -9,6 +9,8 @@
 #define ACOMPONENT_HPP
 
 #include "IComponent.hpp"
+#include "UUID.hpp"
+#include "managers/ObjectManager.hpp"
 
 /**
  * @class AComponent
@@ -71,12 +73,12 @@ protected:
  AComponent(IObject* owner, IMeta& meta);
 
  /**
-  * @brief The owner of the component
+  * @brief The UUID of the component
   * @version v0.1.0
   * @since v0.1.0
-  * @author Marius PAIN
-  */
- IObject* _owner;
+  * @author Aubane NOURRY
+ */
+ UUID _uuid;
 
  /**
   * @brief The meta of the component

--- a/src/common/AField.cpp
+++ b/src/common/AField.cpp
@@ -1,4 +1,5 @@
-/*** EPITECH PROJECT, 2024
+/*
+** EPITECH PROJECT, 2024
 ** StellarForge
 ** File description:
 ** AField.cpp

--- a/src/common/AField.cpp
+++ b/src/common/AField.cpp
@@ -1,0 +1,29 @@
+/*** EPITECH PROJECT, 2024
+** StellarForge
+** File description:
+** AField.cpp
+*/
+
+#include "AField.hpp"
+
+#include <utility>
+
+AField::AField(std::string name, std::string description, const FieldType type): _type(type),
+    _description(std::move(description)), _name(std::move(name))
+{
+}
+
+std::string AField::getName() const
+{
+    return this->_name;
+}
+
+std::string AField::getDescription() const
+{
+    return this->_description;
+}
+
+IComponent::IMeta::IField::FieldType AField::getType() const
+{
+    return this->_type;
+}

--- a/src/common/AField.hpp
+++ b/src/common/AField.hpp
@@ -69,7 +69,7 @@ public:
   */
  [[nodiscard]] FieldType getType() const override;
 
-private:
+protected:
  /**
   * @brief The name of the field
   * @version v0.1.0

--- a/src/common/AField.hpp
+++ b/src/common/AField.hpp
@@ -1,4 +1,5 @@
-/*** EPITECH PROJECT, 2024
+/*
+** EPITECH PROJECT, 2024
 ** StellarForge
 ** File description:
 ** AField.hpp

--- a/src/common/AField.hpp
+++ b/src/common/AField.hpp
@@ -1,0 +1,28 @@
+/*** EPITECH PROJECT, 2024
+** StellarForge
+** File description:
+** AField.hpp
+*/
+
+#ifndef AFIELD_HPP
+#define AFIELD_HPP
+
+#include "IComponent.hpp"
+
+class AField : virtual public IComponent::IMeta::IField
+{
+public:
+    AField(std::string name, std::string description, FieldType type);
+    ~AField() override = default;
+
+    [[nodiscard]] std::string getName() const override;
+    [[nodiscard]] std::string getDescription() const override;
+    [[nodiscard]] FieldType getType() const override;
+
+private:
+    std::string _name;
+    std::string _description;
+    FieldType _type;
+};
+
+#endif //AFIELD_HPP

--- a/src/common/AField.hpp
+++ b/src/common/AField.hpp
@@ -9,20 +9,90 @@
 
 #include "IComponent.hpp"
 
+/**
+ * @class AField
+ * @brief This class is the abstract class for the Field class
+ * @version v0.1.0
+ * @since v0.1.0
+ * @author Marius PAIN
+ */
 class AField : virtual public IComponent::IMeta::IField
 {
 public:
-    AField(std::string name, std::string description, FieldType type);
-    ~AField() override = default;
+ /**
+  * @brief The constructor of the AField class
+  * @param name The name of the field
+  * @param description The description of the field
+  * @param type The type of the field (FieldType)
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ AField(std::string name, std::string description, FieldType type);
 
-    [[nodiscard]] std::string getName() const override;
-    [[nodiscard]] std::string getDescription() const override;
-    [[nodiscard]] FieldType getType() const override;
+ /**
+  * @brief The destructor of the AField class
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ ~AField() override = default;
+
+ /**
+  * @brief Get the name of the field
+  * @see IComponent::IMeta::IField::getName
+  * @return the name of the field
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ [[nodiscard]] std::string getName() const override;
+
+ /**
+  * @brief Get the description of the field
+  * @see IComponent::IMeta::IField::getDescription
+  * @return the description of the field
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ [[nodiscard]] std::string getDescription() const override;
+
+ /**
+  * @brief Get the type of the field
+  * @see IComponent::IMeta::IField::getType
+  * @return the type of the field
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ [[nodiscard]] FieldType getType() const override;
 
 private:
-    std::string _name;
-    std::string _description;
-    FieldType _type;
+ /**
+  * @brief The name of the field
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ std::string _name;
+
+ /**
+  * @brief The description of the field
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ std::string _description;
+
+ /**
+  * @brief The type of the field
+  * @see IComponent::IMeta::IField::FieldType
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ FieldType _type;
 };
 
 #endif //AFIELD_HPP

--- a/src/common/AFieldGroup.cpp
+++ b/src/common/AFieldGroup.cpp
@@ -1,0 +1,30 @@
+/*** EPITECH PROJECT, 2024
+** StellarForge
+** File description:
+** AFieldGroup.cpp
+*/
+
+#include "AFieldGroup.hpp"
+
+#include <utility>
+
+AFieldGroup::AFieldGroup(std::string name, std::string description,
+                         const std::vector<IComponent::IMeta::IField*>& fields):
+    _name(std::move(name)), _description(std::move(description)), _fields(fields)
+{
+}
+
+std::string AFieldGroup::getName() const
+{
+    return this->_name;
+}
+
+std::string AFieldGroup::getDescription() const
+{
+    return this->_description;
+}
+
+std::vector<IComponent::IMeta::IField*> AFieldGroup::getFields() const
+{
+    return this->_fields;
+}

--- a/src/common/AFieldGroup.cpp
+++ b/src/common/AFieldGroup.cpp
@@ -1,4 +1,5 @@
-/*** EPITECH PROJECT, 2024
+/*
+** EPITECH PROJECT, 2024
 ** StellarForge
 ** File description:
 ** AFieldGroup.cpp

--- a/src/common/AFieldGroup.hpp
+++ b/src/common/AFieldGroup.hpp
@@ -1,4 +1,5 @@
-/*** EPITECH PROJECT, 2024
+/*
+** EPITECH PROJECT, 2024
 ** StellarForge
 ** File description:
 ** AFieldGroup.hpp

--- a/src/common/AFieldGroup.hpp
+++ b/src/common/AFieldGroup.hpp
@@ -9,22 +9,92 @@
 
 #include "IComponent.hpp"
 
+/**
+ * @class AFieldGroup
+ * @brief This class is the abstract class for the FieldGroup class
+ * @version v0.1.0
+ * @since v0.1.0
+ * @author Marius PAIN
+ */
 class AFieldGroup : virtual public IComponent::IMeta::IFieldGroup
 {
 public:
-    AFieldGroup(std::string name, std::string description,
-                const std::vector<IComponent::IMeta::IField*>& fields);
-    ~AFieldGroup() override = default;
+ /**
+  * @brief The constructor of the AFieldGroup class
+  * @param name The name of the field group
+  * @param description The description of the field group
+  * @param fields The fields of the field group - vector of IComponent::IMeta::IField
+  * @version v0.1.0
+  * @since v0.1.0
+  */
+ AFieldGroup(std::string name, std::string description,
+             const std::vector<IComponent::IMeta::IField*>& fields);
 
-    [[nodiscard]] std::string getName() const override;
-    [[nodiscard]] std::string getDescription() const override;
-    [[nodiscard]] std::vector<IComponent::IMeta::IField*> getFields() const override;
+ /**
+  * @brief The destructor of the AFieldGroup class
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ ~AFieldGroup() override = default;
+
+ /**
+  * @brief Get the name of the field group
+  * @see IComponent::IMeta::IFieldGroup::getName
+  * @return the name of the field group
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ [[nodiscard]] std::string getName() const override;
+
+ /**
+  * @brief Get the description of the field group
+  * @see IComponent::IMeta::IFieldGroup::getDescription
+  * @return the description of the field group
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ [[nodiscard]] std::string getDescription() const override;
+
+ /**
+  * @brief Get the fields of the field group
+  * @see IComponent::IMeta::IFieldGroup::getFields
+  * @return the fields of the field group
+  * @version v0.1.0
+  * @since v0.1.0
+  * @see IComponent::IMeta::IField
+  * @author Marius PAIN
+  */
+ [[nodiscard]] std::vector<IComponent::IMeta::IField*> getFields() const override;
 
 private:
-    std::string _name;
-    std::string _description;
-    std::vector<IComponent::IMeta::IField*> _fields;
-};
+ /**
+  * @brief The name of the field group
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ std::string _name;
 
+ /**
+  * @brief The description of the field group
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ std::string _description;
+
+ /**
+  * @brief The fields of the field group
+  * @note vector of IComponent::IMeta::IField
+  * @version v0.1.0
+  * @since v0.1.0
+  * @see IComponent::IMeta::IField
+  * @author Marius PAIN
+  */
+ std::vector<IComponent::IMeta::IField*> _fields;
+};
 
 #endif //AFIELDGROUP_HPP

--- a/src/common/AFieldGroup.hpp
+++ b/src/common/AFieldGroup.hpp
@@ -1,0 +1,30 @@
+/*** EPITECH PROJECT, 2024
+** StellarForge
+** File description:
+** AFieldGroup.hpp
+*/
+
+#ifndef AFIELDGROUP_HPP
+#define AFIELDGROUP_HPP
+
+#include "IComponent.hpp"
+
+class AFieldGroup : virtual public IComponent::IMeta::IFieldGroup
+{
+public:
+    AFieldGroup(std::string name, std::string description,
+                const std::vector<IComponent::IMeta::IField*>& fields);
+    ~AFieldGroup() override = default;
+
+    [[nodiscard]] std::string getName() const override;
+    [[nodiscard]] std::string getDescription() const override;
+    [[nodiscard]] std::vector<IComponent::IMeta::IField*> getFields() const override;
+
+private:
+    std::string _name;
+    std::string _description;
+    std::vector<IComponent::IMeta::IField*> _fields;
+};
+
+
+#endif //AFIELDGROUP_HPP

--- a/src/common/AFieldGroup.hpp
+++ b/src/common/AFieldGroup.hpp
@@ -70,7 +70,7 @@ public:
   */
  [[nodiscard]] std::vector<IComponent::IMeta::IField*> getFields() const override;
 
-private:
+protected:
  /**
   * @brief The name of the field group
   * @version v0.1.0

--- a/src/common/AMeta.cpp
+++ b/src/common/AMeta.cpp
@@ -11,9 +11,9 @@
 
 AMeta::AMeta(std::string name, std::string description, const bool isUnique,
              const bool isRemovable,
-             const std::vector<IComponent::IMeta::IFieldGroup>& fieldGroups):
-    _isUnique(isUnique), _isRemovable(isRemovable), _description(std::move(description)),
-    _name(std::move(name)), _fieldGroups(fieldGroups)
+             std::vector<IFieldGroup*>&& fieldGroups):
+    _name(std::move(name)), _description(std::move(description)), _fieldGroups(std::move(fieldGroups)),
+    _isUnique(isUnique), _isRemovable(isRemovable)
 {
 }
 
@@ -37,7 +37,7 @@ bool AMeta::canBeRemoved() const
     return this->_isRemovable;
 }
 
-std::vector<IComponent::IMeta::IFieldGroup> AMeta::getFieldGroups() const
+std::vector<IComponent::IMeta::IFieldGroup*> AMeta::getFieldGroups() const
 {
     return this->_fieldGroups;
 }

--- a/src/common/AMeta.cpp
+++ b/src/common/AMeta.cpp
@@ -1,0 +1,43 @@
+/*
+** EPITECH PROJECT, 2024
+** Stellar-Forge
+** File description:
+** AMeta
+*/
+
+#include "AMeta.hpp"
+
+#include <utility>
+
+AMeta::AMeta(std::string name, std::string description, const bool isUnique,
+             const bool isRemovable,
+             const std::vector<IComponent::IMeta::IFieldGroup>& fieldGroups):
+    _isUnique(isUnique), _isRemovable(isRemovable), _description(std::move(description)),
+    _name(std::move(name)), _fieldGroups(fieldGroups)
+{
+}
+
+std::string AMeta::getName() const
+{
+    return this->_name;
+}
+
+std::string AMeta::getDescription() const
+{
+    return this->_description;
+}
+
+bool AMeta::isUnique() const
+{
+    return this->_isUnique;
+}
+
+bool AMeta::canBeRemoved() const
+{
+    return this->_isRemovable;
+}
+
+std::vector<IComponent::IMeta::IFieldGroup> AMeta::getFieldGroups() const
+{
+    return this->_fieldGroups;
+}

--- a/src/common/AMeta.hpp
+++ b/src/common/AMeta.hpp
@@ -1,0 +1,31 @@
+//
+// Created by marius_pain on 02/10/24.
+//
+
+#ifndef AMETA_HPP
+#define AMETA_HPP
+
+#include "IComponent.hpp"
+
+class AMeta : virtual public IComponent::IMeta
+{
+public:
+    AMeta(std::string name, std::string description, bool isUnique, bool isRemovable,
+          const std::vector<IFieldGroup>& fieldGroups);
+    ~AMeta() override = default;
+
+    [[nodiscard]] std::string getName() const override;
+    [[nodiscard]] std::string getDescription() const override;
+    [[nodiscard]] bool isUnique() const override;
+    [[nodiscard]] bool canBeRemoved() const override;
+    [[nodiscard]] std::vector<IFieldGroup> getFieldGroups() const override;
+
+private:
+    std::string _name;
+    std::string _description;
+    std::vector<IFieldGroup> _fieldGroups;
+    bool _isUnique{};
+    bool _isRemovable{};
+};
+
+#endif //AMETA_HPP

--- a/src/common/AMeta.hpp
+++ b/src/common/AMeta.hpp
@@ -92,7 +92,7 @@ public:
   */
  [[nodiscard]] std::vector<IFieldGroup*> getFieldGroups() const override;
 
-private:
+protected:
  /**
   * @brief The name of the meta
   * @version v0.1.0

--- a/src/common/AMeta.hpp
+++ b/src/common/AMeta.hpp
@@ -1,31 +1,138 @@
-//
-// Created by marius_pain on 02/10/24.
-//
+/*
+** EPITECH PROJECT, 2024
+** Stellar-Forge
+** File description:
+** AMeta
+*/
 
 #ifndef AMETA_HPP
 #define AMETA_HPP
 
 #include "IComponent.hpp"
 
+/**
+ * @class AMeta
+ * @brief This class is the abstract class for the Meta class
+ * @version v0.1.0
+ * @since v0.1.0
+ * @author Marius PAIN
+ */
 class AMeta : virtual public IComponent::IMeta
 {
 public:
-    AMeta(std::string name, std::string description, bool isUnique, bool isRemovable,
-          std::vector<IFieldGroup*>&& fieldGroups);
-    ~AMeta() override = default;
+ /**
+  * @brief The constructor of the AMeta class
+  * @param name The name of the meta
+  * @param description The description of the meta
+  * @param isUnique If the meta is unique
+  * @param isRemovable If the meta can be removed
+  * @param fieldGroups The field groups of the meta
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ AMeta(std::string name, std::string description, bool isUnique, bool isRemovable,
+       std::vector<IFieldGroup*>&& fieldGroups);
 
-    [[nodiscard]] std::string getName() const override;
-    [[nodiscard]] std::string getDescription() const override;
-    [[nodiscard]] bool isUnique() const override;
-    [[nodiscard]] bool canBeRemoved() const override;
-    [[nodiscard]] std::vector<IFieldGroup*> getFieldGroups() const override;
+ /**
+  * @brief The destructor of the AMeta class
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ ~AMeta() override = default;
+
+ /**
+  * @brief Get the name of the meta
+  * @see IComponent::IMeta::getName
+  * @return the name of the meta
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ [[nodiscard]] std::string getName() const override;
+
+ /**
+ * @brief Get the description of the meta
+ * @see IComponent::IMeta::getDescription
+ * @return the description of the meta
+ * @version v0.1.0
+ * @since v0.1.0
+ * @author Marius PAIN
+ */
+ [[nodiscard]] std::string getDescription() const override;
+
+ /**
+  * @brief Check if the meta is unique
+  * @see IComponent::IMeta::isUnique
+  * @return true if the meta is unique, false otherwise
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ [[nodiscard]] bool isUnique() const override;
+
+ /**
+  * @brief Check if the meta can be removed
+  * @see IComponent::IMeta::canBeRemoved
+  * @return true if the meta can be removed, false otherwise
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ [[nodiscard]] bool canBeRemoved() const override;
+
+ /**
+  * @brief Get the field groups of the meta
+  * @see IComponent::IMeta::getFieldGroups
+  * @return the field groups of the meta
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ [[nodiscard]] std::vector<IFieldGroup*> getFieldGroups() const override;
 
 private:
-    std::string _name;
-    std::string _description;
-    std::vector<IFieldGroup*> _fieldGroups;
-    bool _isUnique{};
-    bool _isRemovable{};
+ /**
+  * @brief The name of the meta
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ std::string _name;
+
+ /**
+  * @brief The description of the meta
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ std::string _description;
+
+ /**
+  * @brief The field groups of the meta
+  * @version v0.1.0
+  * @since v0.1.0
+  * @see IComponent::IMeta::IFieldGroup
+  * @author Marius PAIN
+  */
+ std::vector<IFieldGroup*> _fieldGroups;
+
+ /**
+  * @brief If the meta is unique
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ bool _isUnique;
+
+ /**
+  * @brief If the meta can be removed
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Marius PAIN
+  */
+ bool _isRemovable;
 };
 
 #endif //AMETA_HPP

--- a/src/common/AMeta.hpp
+++ b/src/common/AMeta.hpp
@@ -11,19 +11,19 @@ class AMeta : virtual public IComponent::IMeta
 {
 public:
     AMeta(std::string name, std::string description, bool isUnique, bool isRemovable,
-          const std::vector<IFieldGroup>& fieldGroups);
+          std::vector<IFieldGroup*>&& fieldGroups);
     ~AMeta() override = default;
 
     [[nodiscard]] std::string getName() const override;
     [[nodiscard]] std::string getDescription() const override;
     [[nodiscard]] bool isUnique() const override;
     [[nodiscard]] bool canBeRemoved() const override;
-    [[nodiscard]] std::vector<IFieldGroup> getFieldGroups() const override;
+    [[nodiscard]] std::vector<IFieldGroup*> getFieldGroups() const override;
 
 private:
     std::string _name;
     std::string _description;
-    std::vector<IFieldGroup> _fieldGroups;
+    std::vector<IFieldGroup*> _fieldGroups;
     bool _isUnique{};
     bool _isRemovable{};
 };

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -9,6 +9,9 @@ target_sources(StellarForgeCommon
         ${CMAKE_CURRENT_SOURCE_DIR}/IObject.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/IScene.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/IError.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/AMeta.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/AField.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/AFieldGroup.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/UUID.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/UUIDException.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/event/EventData.hpp
@@ -17,6 +20,9 @@ target_sources(StellarForgeCommon
         ${CMAKE_CURRENT_SOURCE_DIR}/managers/SceneManager.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/managers/ManagerException.hpp
         PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/AMeta.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/AField.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/AFieldGroup.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/UUID.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/UUIDException.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/event/EventSystem.cpp

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(StellarForgeCommon
         ${CMAKE_CURRENT_SOURCE_DIR}/IObject.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/IScene.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/IError.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/AComponent.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/AMeta.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/AField.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/AFieldGroup.hpp
@@ -20,6 +21,7 @@ target_sources(StellarForgeCommon
         ${CMAKE_CURRENT_SOURCE_DIR}/managers/SceneManager.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/managers/ManagerException.hpp
         PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/AComponent.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/AMeta.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/AField.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/AFieldGroup.cpp

--- a/src/common/IComponent.hpp
+++ b/src/common/IComponent.hpp
@@ -65,48 +65,6 @@ public:
   virtual ~IMeta() = default;
 
   /**
-   * @brief The copy constructor of the component's meta
-   * Is deleted because the component's meta should not be copied
-   * @param other the other component's meta to copy
-   * @version v0.1.0
-   * @since v0.1.0
-   * @author Axel ECKENBERG
-   */
-  IMeta(const IMeta &other) = delete;
-
-  /**
-   * @brief The copy assignment operator of the component's meta
-   * Is deleted because the component's meta should not be copied
-   * @param other the other component's meta to copy
-   * @return the copied component's meta
-   * @version v0.1.0
-   * @since v0.1.0
-   * @author Axel ECKENBERG
-   */
-  IMeta &operator=(const IMeta &other) = delete;
-
-  /**
-   * @brief The move constructor of the component's meta
-   * Is deleted because the component's meta should not be moved
-   * @param other the other component's meta to move
-   * @version v0.1.0
-   * @since v0.1.0
-   * @author Axel ECKENBERG
-   */
-  IMeta(IMeta &&other) = delete;
-
-  /**
-   * @brief The move assignment operator of the component's meta
-   * Is deleted because the component's meta should not be moved
-   * @param other the other component's meta to move
-   * @return the moved component's meta
-   * @version v0.1.0
-   * @since v0.1.0
-   * @author Axel ECKENBERG
-   */
-  IMeta &operator=(IMeta &&other) = delete;
-
-  /**
    * @brief Returns the name of the component
    * This is used to identify the component but also in the editor
    * display
@@ -191,48 +149,6 @@ public:
    virtual ~IField() = default;
 
    /**
-    * @brief The copy constructor of the field
-    * Is deleted because the field should not be copied
-    * @param other the other field to copy
-    * @version v0.1.0
-    * @since v0.1.0
-    * @author Axel ECKENBERG
-    */
-   IField(const IField &other) = delete;
-
-   /**
-    * @brief The copy assignment operator of the field
-    * Is deleted because the field should not be copied
-    * @param other the other field to copy
-    * @return the copied field
-    * @version v0.1.0
-    * @since v0.1.0
-    * @author Axel ECKENBERG
-    */
-   IField &operator=(const IField &other) = delete;
-
-   /**
-    * @brief The move constructor of the field
-    * Is deleted because the field should not be moved
-    * @param other the other field to move
-    * @version v0.1.0
-    * @since v0.1.0
-    * @author Axel ECKENBERG
-    */
-   IField(IField &&other) = delete;
-
-   /**
-    * @brief The move assignment operator of the field
-    * Is deleted because the field should not be moved
-    * @param other the other field to move
-    * @return the moved field
-    * @version v0.1.0
-    * @since v0.1.0
-    * @author Axel ECKENBERG
-    */
-   IField &operator=(IField &&other) = delete;
-
-   /**
     * @brief Returns the name of the field
     * This is used to identify the field but also in the editor
     * display
@@ -285,48 +201,6 @@ public:
     * @author Axel ECKENBERG
     */
    virtual ~IFieldGroup() = default;
-
-   /**
-    * @brief The copy constructor of the field group
-    * Is deleted because the field group should not be copied
-    * @param other the other field group to copy
-    * @version v0.1.0
-    * @since v0.1.0
-    * @author Axel ECKENBERG
-    */
-   IFieldGroup(const IFieldGroup &other) = delete;
-
-   /**
-    * @brief The copy assignment operator of the field group
-    * Is deleted because the field group should not be copied
-    * @param other the other field group to copy
-    * @return the copied field group
-    * @version v0.1.0
-    * @since v0.1.0
-    * @author Axel ECKENBERG
-    */
-   IFieldGroup &operator=(const IFieldGroup &other) = delete;
-
-   /**
-    * @brief The move constructor of the field group
-    * Is deleted because the field group should not be moved
-    * @param other the other field group to move
-    * @version v0.1.0
-    * @since v0.1.0
-    * @author Axel ECKENBERG
-    */
-   IFieldGroup(IFieldGroup &&other) = delete;
-
-   /**
-    * @brief The move assignment operator of the field group
-    * Is deleted because the field group should not be moved
-    * @param other the other field group to move
-    * @return the moved field group
-    * @version v0.1.0
-    * @since v0.1.0
-    * @author Axel ECKENBERG
-    */
-   IFieldGroup &operator=(IFieldGroup &&other) = delete;
 
    /**
     * @brief Returns the name of the field group

--- a/src/common/IComponent.hpp
+++ b/src/common/IComponent.hpp
@@ -245,7 +245,7 @@ public:
    * @author Axel ECKENBERG
    */
   [[nodiscard]]
-  virtual std::vector<IFieldGroup> getFieldGroups() const = 0;
+  virtual std::vector<IFieldGroup *> getFieldGroups() const = 0;
  };
 
  /**

--- a/src/common/managers/ObjectManager.cpp
+++ b/src/common/managers/ObjectManager.cpp
@@ -100,17 +100,3 @@ void ObjectManager::duplicateObject(const UUID &uuid) {
             "Object with UUID " + uuid.getUuidString() + " not found.");
     }
 }
-
-UUID ObjectManager::generateComponentUUID(IObject *owner, IComponent *component) {
-    auto uuid = UUID();
-    uuid.generateUuid();
-    _components[uuid] = std::make_pair(owner, component);
-    return uuid;
-}
-
-IObject *ObjectManager::getObjectFromComponent(const UUID &uuid) {
-    if (_components.find(uuid) != _components.end()) {
-        return _components[uuid].first;
-    }
-    throw ManagerException("Object with UUID " + uuid.getUuidString() + " not found.");
-}

--- a/src/common/managers/ObjectManager.cpp
+++ b/src/common/managers/ObjectManager.cpp
@@ -101,7 +101,7 @@ void ObjectManager::duplicateObject(const UUID &uuid) {
     }
 }
 
-UUID ObjectManager::get_component_UUID(IObject *owner, IComponent *component) {
+UUID ObjectManager::generate_component_UUID(IObject *owner, IComponent *component) {
     auto uuid = UUID();
     uuid.generateUuid();
     _components[uuid] = std::make_pair(owner, component);

--- a/src/common/managers/ObjectManager.cpp
+++ b/src/common/managers/ObjectManager.cpp
@@ -8,6 +8,11 @@
 #include "ObjectManager.hpp"
 #include "ManagerException.hpp"
 
+ObjectManager &ObjectManager::getInstance() {
+    static ObjectManager instance;
+    return instance;
+}
+
 std::unordered_map<UUID, IObject *> ObjectManager::getObjects() const {
     return _objects;
 }
@@ -94,4 +99,18 @@ void ObjectManager::duplicateObject(const UUID &uuid) {
         throw ManagerException(
             "Object with UUID " + uuid.getUuidString() + " not found.");
     }
+}
+
+UUID ObjectManager::get_component_UUID(IObject *owner, IComponent *component) {
+    auto uuid = UUID();
+    uuid.generateUuid();
+    _components[uuid] = std::make_pair(owner, component);
+    return uuid;
+}
+
+IObject *ObjectManager::get_object_from_component(const UUID &uuid) {
+    if (_components.find(uuid) != _components.end()) {
+        return _components[uuid].first;
+    }
+    throw ManagerException("Object with UUID " + uuid.getUuidString() + " not found.");
 }

--- a/src/common/managers/ObjectManager.cpp
+++ b/src/common/managers/ObjectManager.cpp
@@ -101,14 +101,14 @@ void ObjectManager::duplicateObject(const UUID &uuid) {
     }
 }
 
-UUID ObjectManager::generate_component_UUID(IObject *owner, IComponent *component) {
+UUID ObjectManager::generateComponentUUID(IObject *owner, IComponent *component) {
     auto uuid = UUID();
     uuid.generateUuid();
     _components[uuid] = std::make_pair(owner, component);
     return uuid;
 }
 
-IObject *ObjectManager::get_object_from_component(const UUID &uuid) {
+IObject *ObjectManager::getObjectFromComponent(const UUID &uuid) {
     if (_components.find(uuid) != _components.end()) {
         return _components[uuid].first;
     }

--- a/src/common/managers/ObjectManager.hpp
+++ b/src/common/managers/ObjectManager.hpp
@@ -181,7 +181,7 @@ private:
  ObjectManager() = default;
 
  /**
-  * @brief Destructor for ObjectManager private to prevent instantiation.
+  * @brief Destructor for ObjectManager private to prevent deletion.
   * @version v0.1.0
   * @since v0.1.0
   * @author Aubane NOURRY

--- a/src/common/managers/ObjectManager.hpp
+++ b/src/common/managers/ObjectManager.hpp
@@ -150,27 +150,6 @@ public:
   */
  void duplicateObject(const UUID &uuid);
 
- /**
-  * @brief Generates a UUID for a component and associates it with an object.
-  * @param owner The object to associate the component with.
-  * @param component The component to generate a UUID for.
-  * @return The UUID of the component.
-  * @version v0.1.0
-  * @since v0.1.0
-  * @author Aubane NOURRY
-  */
- UUID generateComponentUUID(IObject *owner, IComponent *component);
-
- /**
-  * @brief Retrieves an object from a component UUID.
-  * @param uuid The UUID of the component.
-  * @return A pointer to the object.
-  * @version v0.1.0
-  * @since v0.1.0
-  * @author Aubane NOURRY
-  */
- IObject *getObjectFromComponent(const UUID &uuid);
-
 private:
  /**
   * @brief Default constructor for ObjectManager private to prevent instantiation.
@@ -188,5 +167,4 @@ private:
   */
  ~ObjectManager() = default;
  std::unordered_map<UUID, IObject *> _objects; ///< Unordered map of object UUIDs to objects.
- std::unordered_map<UUID, std::pair<IObject *, IComponent *>> _components; ///< Unordered map of component UUIDs to object-component pairs.
 };

--- a/src/common/managers/ObjectManager.hpp
+++ b/src/common/managers/ObjectManager.hpp
@@ -159,7 +159,7 @@ public:
   * @since v0.1.0
   * @author Aubane NOURRY
   */
- UUID get_component_UUID(IObject *owner, IComponent *component);
+ UUID generate_component_UUID(IObject *owner, IComponent *component);
 
  /**
   * @brief Retrieves an object from a component UUID.

--- a/src/common/managers/ObjectManager.hpp
+++ b/src/common/managers/ObjectManager.hpp
@@ -159,7 +159,7 @@ public:
   * @since v0.1.0
   * @author Aubane NOURRY
   */
- UUID generate_component_UUID(IObject *owner, IComponent *component);
+ UUID generateComponentUUID(IObject *owner, IComponent *component);
 
  /**
   * @brief Retrieves an object from a component UUID.
@@ -169,7 +169,7 @@ public:
   * @since v0.1.0
   * @author Aubane NOURRY
   */
- IObject *get_object_from_component(const UUID &uuid);
+ IObject *getObjectFromComponent(const UUID &uuid);
 
 private:
  /**

--- a/src/common/managers/ObjectManager.hpp
+++ b/src/common/managers/ObjectManager.hpp
@@ -23,21 +23,13 @@
 class ObjectManager {
 public:
  /**
-  * @brief Default constructor for ObjectManager.
+  * @brief Retrieves the singleton instance of ObjectManager.
+  * @return The single instance of ObjectManager.
   * @version v0.1.0
   * @since v0.1.0
   * @author Aubane NOURRY
-  */
- ObjectManager() = default;
-
- /**
-  * @brief Destructor for ObjectManager.
-  * @version v0.1.0
-  * @since v0.1.0
-  * @author Aubane NOURRY
-  */
- ~ObjectManager() = default;
-
+ */
+ static ObjectManager &getInstance();
  /**
   * @brief Retrieves all objects managed by the ObjectManager.
   * @return An unordered map of UUIDs to object pointers.
@@ -158,6 +150,43 @@ public:
   */
  void duplicateObject(const UUID &uuid);
 
+ /**
+  * @brief Generates a UUID for a component and associates it with an object.
+  * @param owner The object to associate the component with.
+  * @param component The component to generate a UUID for.
+  * @return The UUID of the component.
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+ UUID get_component_UUID(IObject *owner, IComponent *component);
+
+ /**
+  * @brief Retrieves an object from a component UUID.
+  * @param uuid The UUID of the component.
+  * @return A pointer to the object.
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+ IObject *get_object_from_component(const UUID &uuid);
+
 private:
- std::unordered_map<UUID, IObject *> _objects; ///< Unordered map of UUIDs to objects.
+ /**
+  * @brief Default constructor for ObjectManager private to prevent instantiation.
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+ ObjectManager() = default;
+
+ /**
+  * @brief Destructor for ObjectManager private to prevent instantiation.
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+ ~ObjectManager() = default;
+ std::unordered_map<UUID, IObject *> _objects; ///< Unordered map of object UUIDs to objects.
+ std::unordered_map<UUID, std::pair<IObject *, IComponent *>> _components; ///< Unordered map of component UUIDs to object-component pairs.
 };

--- a/src/common/managers/SceneManager.cpp
+++ b/src/common/managers/SceneManager.cpp
@@ -6,8 +6,12 @@
 */
 
 #include "SceneManager.hpp"
-
 #include "ManagerException.hpp"
+
+SceneManager &SceneManager::getInstance() {
+    static SceneManager instance;
+    return instance;
+}
 
 void SceneManager::addScene(const UUID &uuid,
                             IScene *scene,

--- a/src/common/managers/SceneManager.hpp
+++ b/src/common/managers/SceneManager.hpp
@@ -23,23 +23,13 @@
 class SceneManager {
 public:
  /**
-  * @brief Default constructor for SceneManager.
-  * @details Initializes the SceneManager with no scenes and sets the current scene index to -1.
+  * @brief Retrieves the singleton instance of SceneManager.
+  * @return The single instance of SceneManager.
   * @version v0.1.0
   * @since v0.1.0
   * @author Aubane NOURRY
-  */
- SceneManager() = default;
-
- /**
-  * @brief Destructor for SceneManager.
-  * @details Cleans up the SceneManager when it is no longer in use.
-  * @version v0.1.0
-  * @since v0.1.0
-  * @author Aubane NOURRY
-  */
- ~SceneManager() = default;
-
+ */
+ static SceneManager &getInstance();
  /**
   * @brief Adds a scene to the manager.
   * @param uuid The unique identifier of the scene.
@@ -163,6 +153,24 @@ public:
  bool isSceneExist(const UUID &uuid) const;
 
 private:
+ /**
+  * @brief Default constructor for SceneManager private to prevent creation.
+  * @details Initializes the SceneManager with no scenes.
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+ SceneManager() = default;
+
+ /**
+  * @brief Destructor for SceneManager private to prevent deletion.
+  * @details Cleans up the SceneManager when it is no longer in use.
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+ ~SceneManager() = default;
+
  std::map<UUID, IScene *> _scenes; ///< Map of UUIDs to scenes.
  std::vector<UUID> _sceneOrder; ///< Order of the scenes.
  int _currentSceneIndex{-1}; ///< The index of the current scene.


### PR DESCRIPTION
This pull request introduces new classes and refactors existing interfaces to improve the structure and functionality of the `StellarForge` project. The changes include the addition of `AField`, `AFieldGroup`, and `AMeta` classes, as well as the removal of deleted constructors and operators from the `IComponent` interface.

### New Classes:

* `src/common/AField.cpp` and `src/common/AField.hpp`: Added `AField` class to represent individual fields with attributes such as name, description, and type. [[1]](diffhunk://#diff-0831262199525f0584640bded62d2a83c8b60e917edc71ea452bd094496dbe3eR1-R29) [[2]](diffhunk://#diff-1bb357630a1c2b1123b268be59720073f293b1e1e1a12f1863bd7b162d4d96ceR1-R28)
* `src/common/AFieldGroup.cpp` and `src/common/AFieldGroup.hpp`: Added `AFieldGroup` class to group multiple fields together, each with a name and description. [[1]](diffhunk://#diff-7f36d32f75c5913ca0ee9b06c956a7a8d99a34e96c3ec0730e0e845380a08a25R1-R30) [[2]](diffhunk://#diff-dc538536da07f3919776f8dbbd9e696e8a40ee5aa094aaef6fb58459351d19fbR1-R30)
* `src/common/AMeta.cpp` and `src/common/AMeta.hpp`: Added `AMeta` class to represent metadata with attributes like uniqueness, removability, and associated field groups. [[1]](diffhunk://#diff-89372bea01a72da30878c83a90b3aec2dec54b2b34656bf500cfaad97f953960R1-R43) [[2]](diffhunk://#diff-beb8b2c6dfc166850f3e51e30fcfe26b49439846e5da935f994b4c3fbcc9673dR1-R31)

### Interface Refactoring:

* [`src/common/IComponent.hpp`](diffhunk://#diff-501b2cab76de290d4794d7ed087e653e88b402eb087827fab7f1578b75271e85L67-L108): Removed deleted copy/move constructors and assignment operators from `IMeta`, `IField`, and `IFieldGroup` interfaces to simplify the code and avoid unnecessary restrictions. [[1]](diffhunk://#diff-501b2cab76de290d4794d7ed087e653e88b402eb087827fab7f1578b75271e85L67-L108) [[2]](diffhunk://#diff-501b2cab76de290d4794d7ed087e653e88b402eb087827fab7f1578b75271e85L193-L234) [[3]](diffhunk://#diff-501b2cab76de290d4794d7ed087e653e88b402eb087827fab7f1578b75271e85L289-L330)

### CMake Configuration:

* [`src/common/CMakeLists.txt`](diffhunk://#diff-623b734f767b84dff28cb49ebd68b44d56a1a0eabcc436fed6cd0ed74eb7b19fR12-R14): Updated to include the new `AMeta`, `AField`, and `AFieldGroup` source and header files in the build process. [[1]](diffhunk://#diff-623b734f767b84dff28cb49ebd68b44d56a1a0eabcc436fed6cd0ed74eb7b19fR12-R14) [[2]](diffhunk://#diff-623b734f767b84dff28cb49ebd68b44d56a1a0eabcc436fed6cd0ed74eb7b19fR23-R25)