### PR TITLE
:zap: Add onStart and onDelete functions (EPI-98/EPI-99)

### DIFF
--- a/src/common/AComponent.cpp
+++ b/src/common/AComponent.cpp
@@ -15,6 +15,10 @@ void AComponent::onStart()
 {
 }
 
+void AComponent::onDelete()
+{
+}
+
 void AComponent::beforeRendering()
 {
 }

--- a/src/common/AComponent.cpp
+++ b/src/common/AComponent.cpp
@@ -11,6 +11,10 @@ AComponent::AComponent(IObject *owner, const IMeta &meta) : _owner(owner), _meta
 {
 }
 
+void AComponent::onStart()
+{
+}
+
 void AComponent::beforeRendering()
 {
 }

--- a/src/common/AComponent.cpp
+++ b/src/common/AComponent.cpp
@@ -11,11 +11,11 @@ AComponent::AComponent(IObject *owner, const IMeta &meta) : _owner(owner), _meta
 {
 }
 
-void AComponent::onStart()
+void AComponent::onCreation()
 {
 }
 
-void AComponent::onDelete()
+void AComponent::onDeletion()
 {
 }
 

--- a/src/common/AComponent.hpp
+++ b/src/common/AComponent.hpp
@@ -29,26 +29,26 @@ public:
  ~AComponent() override = default;
 
  /**
-  * @brief The start function of the component
+  * @brief The creation function of the component
   * * This is meant to be runt by the parent object and initialize the component
   * @note This is not a pure virtual function and can be overriden in the child class
-  * @see IComponent::onStart
+  * @see IComponent::onCreation
   * @version v0.1.0
   * @since v0.1.0
   * @author Aubane NOURRY
   */
-  void onStart() override;
+  void onCreation() override;
 
   /**
-  * @brief The delete function of the component
+  * @brief The deletion function of the component
   * * This is meant to be runt by the parent object and delete the component
   * @note This is not a pure virtual function and can be overriden in the child class
-  * @see IComponent::onDelete
+  * @see IComponent::onDeletion
   * @version v0.1.0
   * @since v0.1.0
   * @author Aubane NOURRY
   */
-  void onDelete() override;
+  void onDeletion() override;
 
  /**
   * @brief The before function of the component

--- a/src/common/AComponent.hpp
+++ b/src/common/AComponent.hpp
@@ -39,6 +39,17 @@ public:
   */
   void onStart() override;
 
+  /**
+  * @brief The delete function of the component
+  * * This is meant to be runt by the parent object and delete the component
+  * @note This is not a pure virtual function and can be overriden in the child class
+  * @see IComponent::onDelete
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+  void onDelete() override;
+
  /**
   * @brief The before function of the component
   * This is meant to be runt by the parent object and update the component before the rendering

--- a/src/common/AComponent.hpp
+++ b/src/common/AComponent.hpp
@@ -29,6 +29,17 @@ public:
  ~AComponent() override = default;
 
  /**
+  * @brief The start function of the component
+  * * This is meant to be runt by the parent object and initialize the component
+  * @note This is not a pure virtual function and can be overriden in the child class
+  * @see IComponent::onStart
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+  void onStart() override;
+
+ /**
   * @brief The before function of the component
   * This is meant to be runt by the parent object and update the component before the rendering
   * @note This is not a pure virtual function and can be overriden in the child class

--- a/src/common/IComponent.hpp
+++ b/src/common/IComponent.hpp
@@ -37,6 +37,14 @@ public:
   * This is meant to be runt by the parent object and initialize the component
   * @version v0.1.0
   * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+ virtual void onStart() = 0;
+ /**
+  * @brief The start function of the component
+  * This is meant to be runt before the rendering of the component
+  * @version v0.1.0
+  * @since v0.1.0
   * @author Marius PAIN
   */
  virtual void beforeRendering() = 0;

--- a/src/common/IComponent.hpp
+++ b/src/common/IComponent.hpp
@@ -40,6 +40,16 @@ public:
   * @author Aubane NOURRY
   */
  virtual void onStart() = 0;
+
+ /**
+  * @brief The delete function of the component
+  * This is meant to be runt by the parent object and delete the component
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+ virtual void onDelete() = 0;
+
  /**
   * @brief The start function of the component
   * This is meant to be runt before the rendering of the component

--- a/src/common/IComponent.hpp
+++ b/src/common/IComponent.hpp
@@ -33,22 +33,22 @@ public:
  virtual ~IComponent() = default;
 
  /**
-  * @brief The start function of the component
+  * @brief The creation function of the component
   * This is meant to be runt by the parent object and initialize the component
   * @version v0.1.0
   * @since v0.1.0
   * @author Aubane NOURRY
   */
- virtual void onStart() = 0;
+ virtual void onCreation() = 0;
 
  /**
-  * @brief The delete function of the component
-  * This is meant to be runt by the parent object and delete the component
+  * @brief The deletion function of the component
+  * This is meant to be runt by the parent object and deletion the component
   * @version v0.1.0
   * @since v0.1.0
   * @author Aubane NOURRY
   */
- virtual void onDelete() = 0;
+ virtual void onDeletion() = 0;
 
  /**
   * @brief The start function of the component

--- a/src/common/components/CPPMonoBehaviour.cpp
+++ b/src/common/components/CPPMonoBehaviour.cpp
@@ -9,6 +9,11 @@
 #include "../fields/FieldGroup.hpp"
 #include "../fields/FileField.hpp"
 
+void CPPMonoBehaviour::onStart()
+{
+    start();
+}
+
 void CPPMonoBehaviour::beforeRendering()
 {
     before();

--- a/src/common/components/CPPMonoBehaviour.cpp
+++ b/src/common/components/CPPMonoBehaviour.cpp
@@ -9,12 +9,12 @@
 #include "../fields/FieldGroup.hpp"
 #include "../fields/FileField.hpp"
 
-void CPPMonoBehaviour::onStart()
+void CPPMonoBehaviour::onCreation()
 {
     start();
 }
 
-void CPPMonoBehaviour::onDelete()
+void CPPMonoBehaviour::onDeletion()
 {
     end();
 }

--- a/src/common/components/CPPMonoBehaviour.cpp
+++ b/src/common/components/CPPMonoBehaviour.cpp
@@ -14,6 +14,11 @@ void CPPMonoBehaviour::onStart()
     start();
 }
 
+void CPPMonoBehaviour::onDelete()
+{
+    end();
+}
+
 void CPPMonoBehaviour::beforeRendering()
 {
     before();

--- a/src/common/components/CPPMonoBehaviour.hpp
+++ b/src/common/components/CPPMonoBehaviour.hpp
@@ -40,6 +40,17 @@ public:
   */
   void onStart() final;
 
+  /**
+  * @brief The delete function of the component
+  * This is meant to be runt by the parent object and initialize the component
+  * @note This is not supposed to be overriden in the child class (you should modify the delete function instead)
+  * @see IComponent::onDelete
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+  void onDelete() final;
+
  /**
   * @brief The before function of the component
   * This is meant to be runt by the parent object and update the component before the rendering
@@ -83,6 +94,17 @@ public:
   * @author Aubane NOURRY
   */
  virtual void start() = 0;
+
+ /**
+  * @brief The delete function of the component
+  * This is meant to be runt by the parent object and delete the component
+  * @note This is a pure virtual function and must be implemented in the child class
+  * @see IComponent::onDelete
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+ virtual void end() = 0;
 
  /**
   * @brief The start function of the component

--- a/src/common/components/CPPMonoBehaviour.hpp
+++ b/src/common/components/CPPMonoBehaviour.hpp
@@ -30,26 +30,26 @@ public:
  ~CPPMonoBehaviour() override = default;
 
  /**
-  * @brief The start function of the component
+  * @brief The creation function of the component
   * This is meant to be runt by the parent object and initialize the component
   * @note This is not supposed to be overriden in the child class (you should modify the start function instead)
-  * @see IComponent::onStart
+  * @see IComponent::onCreation
   * @version v0.1.0
   * @since v0.1.0
   * @author Aubane NOURRY
   */
-  void onStart() final;
+  void onCreation() final;
 
   /**
-  * @brief The delete function of the component
-  * This is meant to be runt by the parent object and initialize the component
+  * @brief The deletion function of the component
+  * This is meant to be runt by the parent object and delete the component
   * @note This is not supposed to be overriden in the child class (you should modify the delete function instead)
   * @see IComponent::onDelete
   * @version v0.1.0
   * @since v0.1.0
   * @author Aubane NOURRY
   */
-  void onDelete() final;
+  void onDeletion() final;
 
  /**
   * @brief The before function of the component

--- a/src/common/components/CPPMonoBehaviour.hpp
+++ b/src/common/components/CPPMonoBehaviour.hpp
@@ -30,6 +30,17 @@ public:
  ~CPPMonoBehaviour() override = default;
 
  /**
+  * @brief The start function of the component
+  * This is meant to be runt by the parent object and initialize the component
+  * @note This is not supposed to be overriden in the child class (you should modify the start function instead)
+  * @see IComponent::onStart
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+  void onStart() final;
+
+ /**
   * @brief The before function of the component
   * This is meant to be runt by the parent object and update the component before the rendering
   * @note This is not supposed to be overriden in the child class (you should modify the before function instead)
@@ -61,6 +72,17 @@ public:
   * @author Marius PAIN
   */
  void afterRendering() final;
+
+ /**
+  * @brief The start function of the component
+  * This is meant to be runt by the parent object and initialize the component
+  * @note This is a pure virtual function and must be implemented in the child class
+  * @see IComponent::onStart
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+ virtual void start() = 0;
 
  /**
   * @brief The start function of the component


### PR DESCRIPTION
This pull request introduces new lifecycle methods to the `AComponent` and `CPPMonoBehaviour` classes, enhancing their initialization and cleanup processes. The primary changes include adding `onStart` and `onDelete` methods to both classes and updating the `IComponent` interface accordingly.

### Lifecycle Methods Addition:

* [`src/common/AComponent.cpp`](diffhunk://#diff-86381311cee8d358b69d05b331f9a4ea0a02bf916eaf02718e0a6d0b97edf3afR14-R21): Added `onStart` and `onDelete` methods to the `AComponent` class.
* [`src/common/AComponent.hpp`](diffhunk://#diff-5f115ef96e25db6b2962ecdfbd18e93552654dc619405fcc1ac3e39597abf567R31-R52): Documented and declared the `onStart` and `onDelete` methods in the `AComponent` class.
* [`src/common/IComponent.hpp`](diffhunk://#diff-501b2cab76de290d4794d7ed087e653e88b402eb087827fab7f1578b75271e85R40-R57): Added pure virtual `onStart` and `onDelete` methods to the `IComponent` interface.

### Integration with CPPMonoBehaviour:

* [`src/common/components/CPPMonoBehaviour.cpp`](diffhunk://#diff-1c510a9f30351595b2a9a912377b5f4043b152c70a22e90df9922e95c113a197R12-R21): Implemented the `onStart` and `onDelete` methods to call the respective `start` and `end` methods.
* [`src/common/components/CPPMonoBehaviour.hpp`](diffhunk://#diff-229a65316f64f5691bcb6684f7a74545f89006a93198544f586364c33810b08bR32-R53): Declared `onStart` and `onDelete` as final methods and introduced pure virtual `start` and `end` methods for further customization in derived classes. [[1]](diffhunk://#diff-229a65316f64f5691bcb6684f7a74545f89006a93198544f586364c33810b08bR32-R53) [[2]](diffhunk://#diff-229a65316f64f5691bcb6684f7a74545f89006a93198544f586364c33810b08bR87-R108)