### PR TITLE
🔨 Update cmake to fix exported headers (EPI-110)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,11 @@ foreach (source IN LISTS StellarForgeGraphics_SOURCES)
     endif ()
 endforeach ()
 
-# Export headers in build directory
-file(COPY ${StellarForge_HEADERS} DESTINATION ${CMAKE_BINARY_DIR}/includes/StellarForge)
+foreach (header IN LISTS StellarForge_HEADERS)
+    string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/src/" "" new_header ${header})
+    set(new_header "StellarForge/${new_header}")
+    get_filename_component(header_dir ${new_header} DIRECTORY)
+    file(COPY ${header} DESTINATION include/${header_dir})
+endforeach ()
 
 add_subdirectory(tests)


### PR DESCRIPTION
This pull request includes changes to the `CMakeLists.txt` file to improve the handling of header files. The most important change is the modification of how headers are copied to the build directory.

Changes to header file handling:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL81-R86): Replaced the `file(COPY ...)` command with a `foreach` loop to copy each header individually, ensuring the directory structure is preserved.