### PR TITLE
:zap: Add setActive to IObject class (EPI-111)

### DIFF
--- a/src/common/IObject.hpp
+++ b/src/common/IObject.hpp
@@ -143,6 +143,15 @@ public:
   */
  virtual bool isActive() = 0;
 
+  /**
+  * @brief This function is used to set the object active or not.
+  * @param active The new state of the object
+  * @version v0.1.0
+  * @since v0.1.0
+  * @author Aubane NOURRY
+  */
+ virtual void setActive(bool active) = 0;
+
  /**
   * @class IMeta
   * @brief This is the interface for the object's meta class.

--- a/src/common/VirtualObject.hpp
+++ b/src/common/VirtualObject.hpp
@@ -45,7 +45,7 @@ public:
 
     bool isActive() override;
 
-    void setActive(bool active);
+    void setActive(bool active) override;
 
     [[nodiscard]] IMeta &getMeta() const override;
 


### PR DESCRIPTION
This pull request introduces a new method to the `IObject` interface and ensures its implementation in the `VirtualObject` class. The most important changes include adding the `setActive` method to the `IObject` interface and updating the `VirtualObject` class to override this method.

Changes to `IObject` interface:

* [`src/common/IObject.hpp`](diffhunk://#diff-4a36ae616a4b46000f5a79ea2107c8a7372a6fe250df8b6709b6fb0f9c6f56d3R146-R154): Added the `setActive` method to the `IObject` interface, allowing objects to be set as active or inactive.

Changes to `VirtualObject` class:

* [`src/common/VirtualObject.hpp`](diffhunk://#diff-b1437b638a7c45761004e3ca051f8889f23c2d0fc68eac3e9e4170eaf502c3a5L48-R48): Updated the `setActive` method in the `VirtualObject` class to override the new method in the `IObject` interface.