### PR TITLE
🐛  Fix Scene manager and Component initialization

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,3 +26,4 @@ Checks: >
   -boost-*,
   -*-no-recursion,
   -*-function-cognitive-complexity,
+  -*-use-anonymous-namespace,

--- a/src/common/factories/ComponentFactory.cpp
+++ b/src/common/factories/ComponentFactory.cpp
@@ -11,7 +11,9 @@
 IComponent *ComponentFactory::create(const std::string &typeName, IObject *owner,
                                      const json::JsonObject *data) {
     if (registry().find(typeName) != registry().end()) {
-        return registry()[typeName](owner, data);
+        auto *comp = registry()[typeName](owner, data);
+        comp->onCreation();
+        return comp;
     }
     return nullptr;
 }

--- a/src/common/managers/ObjectManager.cpp
+++ b/src/common/managers/ObjectManager.cpp
@@ -95,6 +95,7 @@ UUID ObjectManager::duplicateObject(const UUID &uuid) {
         auto newId = UUID(uuid);
         newId.generateUuid();
         addObject(newId, newObject);
+        SceneManager::getInstance().getCurrentScene()->addObject(newObject);
         return newId;
     }
     throw ManagerException(

--- a/src/common/managers/ObjectManager.hpp
+++ b/src/common/managers/ObjectManager.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include "common/IObject.hpp"
 #include "common/UUID.hpp"
+#include "SceneManager.hpp"
 
 /**
  * @class ObjectManager

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -147,14 +147,14 @@ bool Engine::_isValideObject(const json::IJsonObject *data) {
     if (!obj->contains("child")) {
         return false;
     }
-    if (!obj->contains("active")) {
+    if (!obj->contains("isActive")) {
         return false;
     }
     auto const *const uid = obj->getValue<json::IJsonObject>("id");
     auto const *const meta = obj->getValue<json::IJsonObject>("meta");
     auto const *const child = obj->getValue<json::IJsonObject>("child");
     auto const *const comps = obj->getValue<json::IJsonObject>("components");
-    auto const *const active = obj->getValue<json::IJsonObject>("active");
+    auto const *const active = obj->getValue<json::IJsonObject>("isActive");
 
     if (uid == nullptr) {
         return false;

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -28,7 +28,7 @@ Graphics::~Graphics() {
 }
 
 template <typename T>
-T *getObjComponent(IObject *object) {
+static T *getObjComponent(IObject *object) {
     for (auto *component: object->getComponents()) {
         if (auto *comp = dynamic_cast<T *>(component)) {
             return comp;
@@ -42,8 +42,8 @@ void Graphics::addAndSortObject(IObject *object) {
         sortedObjects.push_back(object);
         return;
     }
-    auto it = std::find(sortedObjects.begin(), sortedObjects.end(), object);
-    if (it == sortedObjects.end()) {
+    auto obj = std::find(sortedObjects.begin(), sortedObjects.end(), object);
+    if (obj == sortedObjects.end()) {
         sortedObjects.push_back(object);
     }
 }
@@ -217,9 +217,9 @@ void Graphics::render(const std::function<void(IObject *)> &updateFunction) {
         addAndSortObject(object);
     }
     std::sort(sortedObjects.begin(), sortedObjects.end(),
-              [](IObject *a, IObject *b) {
-                  Transform *aTransform = getObjComponent<Transform>(a);
-                  Transform *bTransform = getObjComponent<Transform>(b);
+              [](IObject *obja, IObject *objb) {
+                  auto *aTransform = getObjComponent<Transform>(obja);
+                  auto *bTransform = getObjComponent<Transform>(objb);
                   if (aTransform == nullptr || bTransform == nullptr) {
                       return false;
                   }

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -20,6 +20,7 @@ Graphics::Graphics(const int width, const int height, const std::string &title,
     window.setFramerateLimit(60);
     sortedObjects.reserve(100);
     currentScene = SceneManager::getInstance().getCurrentScene();
+    keysPressed.reserve(10);
 }
 
 Graphics::~Graphics() {
@@ -181,12 +182,29 @@ void Graphics::catchEvents() {
             close();
         }
         if (event.type == sf::Event::KeyPressed) {
+            bool alreadyPressed = false;
+            for (auto key: keysPressed) {
+                if (key == event.key.code) {
+                    alreadyPressed = true;
+                    break;
+                }
+            }
+            if (alreadyPressed) {
+                continue;
+            }
             const std::string keyName = keyToString(event.key.code);
             EventSystem::getInstance().triggerEvents(keyName + "_pressed", nullptr);
+            keysPressed.push_back(event.key.code);
         }
         if (event.type == sf::Event::KeyReleased) {
             const std::string keyName = keyToString(event.key.code);
             EventSystem::getInstance().triggerEvents(keyName + "_released", nullptr);
+            for (auto key = keysPressed.begin(); key != keysPressed.end(); ++key) {
+                if (*key == event.key.code) {
+                    keysPressed.erase(key);
+                    break;
+                }
+            }
         }
     }
 }

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -19,6 +19,7 @@ Graphics::Graphics(const int width, const int height, const std::string &title,
     prepared = true;
     window.setFramerateLimit(60);
     sortedObjects.reserve(100);
+    currentScene = SceneManager::getInstance().getCurrentScene();
 }
 
 Graphics::~Graphics() {
@@ -193,6 +194,9 @@ void Graphics::catchEvents() {
 void Graphics::render(const std::function<void(IObject *)> &updateFunction) {
     if (!prepared) {
         return;
+    }
+    if (currentScene == nullptr) {
+        currentScene = SceneManager::getInstance().getCurrentScene();
     }
     clear();
 

--- a/src/graphics/Graphics.hpp
+++ b/src/graphics/Graphics.hpp
@@ -153,6 +153,7 @@ private:
  bool precharge;
  /**< Flag to indicate if all objects should be preloaded in all scenes. */
  IScene *currentScene; /**< The current scene being rendered. */
+ std::vector<sf::Keyboard::Key> keysPressed; /**< The keys currently pressed. */
 };
 
 #endif // GRAPHICS_HPP

--- a/src/graphics/Graphics.hpp
+++ b/src/graphics/Graphics.hpp
@@ -14,6 +14,7 @@
 #include "common/event/EventSystem.hpp"
 #include "common/components/Transform.hpp"
 #include "components/IGraphicsComponent.hpp"
+#include "common/managers/SceneManager.hpp"
 #include "GraphicsException.hpp"
 
 #include <iostream>

--- a/tests/assets/objects/test-ally.json
+++ b/tests/assets/objects/test-ally.json
@@ -3,7 +3,7 @@
   "meta": {
     "name": "Ally"
   },
-  "active": false,
+  "isActive": false,
   "child": [],
   "components": [
     {


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes to the `ComponentFactory`, `ObjectManager`, `Engine`, and `Graphics` classes. The most significant changes include adding an `onCreation` callback for components, ensuring objects are added to the current scene upon duplication, updating key naming conventions, and improving the `Graphics` class to handle key events and object sorting more efficiently.

### Enhancements to Component Creation and Management:

* [`src/common/factories/ComponentFactory.cpp`](diffhunk://#diff-1298fd268d541956df0f2766c8e49828a8c3bc475f75f44eca507bbd868334aaL14-R16): Added an `onCreation` callback to the `ComponentFactory::create` method to initialize components upon creation.
* [`src/common/managers/ObjectManager.cpp`](diffhunk://#diff-463d437e014f6826e5477ae5ddc588df18def1dd7a592d080fd8ad8471fbcbe0R98): Ensured duplicated objects are added to the current scene in the `ObjectManager::duplicateObject` method.
* [`src/common/managers/ObjectManager.hpp`](diffhunk://#diff-eacf8a8ab0b6f96a69271a91b2b5604cc2c518f539e5cbf9dcc18a18a0a83a29R14): Included the `SceneManager` header to support scene management in `ObjectManager`.

### Bug Fixes and Improvements in Engine and Graphics:

* [`src/engine/Engine.cpp`](diffhunk://#diff-792e7ee9541fb28c61cdf063f032057c64c788f41fe955bae6b5c1a702f2f15bL150-R157): Updated key naming convention from `active` to `isActive` in the `_isValideObject` method to match the JSON schema.
* `src/graphics/Graphics.cpp`: 
  * Introduced a utility template function `getObjComponent` to retrieve components of a specific type from an object.
  * Enhanced `addAndSortObject` to avoid duplicate entries and added sorting logic in the `render` method based on the `z` position of objects. [[1]](diffhunk://#diff-1f6629087aa105bc8673367f0a62763b3f9c2b2e562c19a6a6cf2a5c98c3233cR22-L53) [[2]](diffhunk://#diff-1f6629087aa105bc8673367f0a62763b3f9c2b2e562c19a6a6cf2a5c98c3233cR209-R227)
  * Improved `catchEvents` to track and handle key press and release events more efficiently.
* [`src/graphics/Graphics.hpp`](diffhunk://#diff-65a5c7b1b6cd57f7d1effc5cf30fffbfb521a3992c072670c6012051c171f764R17): Added a member to track keys currently pressed and included the `SceneManager` header for scene management. [[1]](diffhunk://#diff-65a5c7b1b6cd57f7d1effc5cf30fffbfb521a3992c072670c6012051c171f764R17) [[2]](diffhunk://#diff-65a5c7b1b6cd57f7d1effc5cf30fffbfb521a3992c072670c6012051c171f764R156)