### PR TITLE
:bug: Fix incompatible enum with Windows

### DIFF
--- a/src/common/utils/Logger.cpp
+++ b/src/common/utils/Logger.cpp
@@ -69,17 +69,17 @@ static std::string getCurrentTimeToString() {
 
 void Logger::log(const std::string &message, const Level level) const {
     switch (level) {
-        case Level::DEBUG:
+        case Level::LOG_DEBUG:
             this->debug << message;
             break;
         default:
-        case Level::INFO:
+        case Level::LOG_INFO:
             this->info << message;
             break;
-        case Level::WARNING:
+        case Level::LOG_WARNING:
             this->warn << message;
             break;
-        case Level::ERROR:
+        case Level::LOG_ERROR:
             this->error << message;
             break;
     }

--- a/src/common/utils/Logger.hpp
+++ b/src/common/utils/Logger.hpp
@@ -134,10 +134,10 @@ public:
     ErrorLevel error;
 
     enum class Level: uint8_t {
-        DEBUG,
-        INFO,
-        WARNING,
-        ERROR
+        LOG_DEBUG,
+        LOG_INFO,
+        LOG_WARNING,
+        LOG_ERROR
     };
 
     explicit Logger(std::ostream *output = &std::cout,
@@ -149,7 +149,7 @@ public:
 
     ~Logger() = default;
 
-    void log(const std::string &message, Level level = Level::INFO) const;
+    void log(const std::string &message, Level level = Level::LOG_INFO) const;
 
     Logger &operator=(const Logger &other);
 };


### PR DESCRIPTION
This pull request involves renaming the log levels in the `Logger` class to improve clarity and consistency. The most important changes include updating the log level enumerations and modifying the `log` method to use the new log level names.

Changes to log level enumerations:

* [`src/common/utils/Logger.hpp`](diffhunk://#diff-1fe79180ce5f329101e3f67f710803086a146afc7e1e03b30ff3b7258a7239beL137-R140): Renamed log levels from `DEBUG`, `INFO`, `WARNING`, and `ERROR` to `LOG_DEBUG`, `LOG_INFO`, `LOG_WARNING`, and `LOG_ERROR` respectively.

Updates to the `log` method:

* [`src/common/utils/Logger.hpp`](diffhunk://#diff-1fe79180ce5f329101e3f67f710803086a146afc7e1e03b30ff3b7258a7239beL152-R152): Updated the `log` method signature to use the new log level name `LOG_INFO` as the default parameter.
* [`src/common/utils/Logger.cpp`](diffhunk://#diff-285ff3a2ee30567af4ccb85040c3238c79c3d8374211f7b1a73d15d4bc47096fL72-R82): Modified the `log` method implementation to switch on the new log level names `LOG_DEBUG`, `LOG_INFO`, `LOG_WARNING`, and `LOG_ERROR`.