### PR TITLE
:building_construction: Change the cmake version to be compliant with debian 12 (EPI-173)

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.25)
 set(CMAKE_CXX_STANDARD 17)
 
 project(StellarForgeCommon

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.25)
 set(CMAKE_CXX_STANDARD 17)
 
 project(StellarForgeEngine

--- a/src/engine3D/CMakeLists.txt
+++ b/src/engine3D/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.25)
 set(CMAKE_CXX_STANDARD 17)
 
 project(StellarForgeEngine3Dd

--- a/src/graphics/CMakeLists.txt
+++ b/src/graphics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.25)
 set(CMAKE_CXX_STANDARD 17)
 
 project(StellarForgeGraphics

--- a/src/graphics3D/CMakeLists.txt
+++ b/src/graphics3D/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.25)
 set(CMAKE_CXX_STANDARD 17)
 
 project(StellarForgeGraphics3D

--- a/src/physics/CMakeLists.txt
+++ b/src/physics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.25)
 set(CMAKE_CXX_STANDARD 17)
 
 project(StellarForgePhysics


### PR DESCRIPTION
This pull request includes changes to the minimum required CMake version across multiple project files to ensure consistency. The CMake version has been downgraded from 3.28 and 3.27 to 3.25.

Changes to CMake version requirements:

* [`src/common/CMakeLists.txt`](diffhunk://#diff-623b734f767b84dff28cb49ebd68b44d56a1a0eabcc436fed6cd0ed74eb7b19fL1-R1): Changed minimum required CMake version from 3.28 to 3.25.
* [`src/engine/CMakeLists.txt`](diffhunk://#diff-27c67349eec693604511f7df6fceda6a3f332ae0d75f32761307a64b4cd3b0b7L1-R1): Changed minimum required CMake version from 3.28 to 3.25.
* [`src/engine3D/CMakeLists.txt`](diffhunk://#diff-208e3cffa3b5e482bc741e24c5ba8f20021b7bb94b297d9575b927f49f0255f0L1-R1): Changed minimum required CMake version from 3.27 to 3.25.
* [`src/graphics/CMakeLists.txt`](diffhunk://#diff-11a59fa4b532ee3177beccd92e47861565367f6e4738f3cd38ff113758b3c12aL1-R1): Changed minimum required CMake version from 3.27 to 3.25.
* [`src/graphics3D/CMakeLists.txt`](diffhunk://#diff-613ed84fee75c5a6b58d399c1e0df65a963316d168fa0cf4cab208bc733537bfL1-R1): Changed minimum required CMake version from 3.27 to 3.25.
* [`src/physics/CMakeLists.txt`](diffhunk://#diff-29f986a046da0e040fba70e87fd86e6fe1630e78b236f8c17457fc2fafe6b2d6L1-R1): Changed minimum required CMake version from 3.28 to 3.25.